### PR TITLE
Adjusting timming deployment/resource

### DIFF
--- a/argo/elastic-hq/deployments/elastichq-deployment.yaml
+++ b/argo/elastic-hq/deployments/elastichq-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app: elastic-hq
-  replicas: 2
+  replicas: 6
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -27,8 +27,8 @@ spec:
         - containerPort: 5000
         resources:
           limits:
-            memory: 500Mi
-            cpu: 200m
+            memory: 50Mi
+            cpu: 50m
           requests:
-            memory: 100Mi
+            memory: 10Mi
             cpu: 10m

--- a/argo/example-app/deployments/deployment.yaml
+++ b/argo/example-app/deployments/deployment.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: example-app
-  replicas: 3
+  replicas: 6
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -28,9 +28,9 @@ spec:
         ports:
         - containerPort: 5000
         resources:
-          requests:
-            memory: "64Mi"
-            cpu: "50m"
           limits:
-            memory: "256Mi"
-            cpu: "500m"
+            memory: 100Mi
+            cpu: 100m
+          requests:
+            memory: 64Mi
+            cpu: 50m


### PR DESCRIPTION
Ajustei o numero de replicas e a distribuição de recursos dentro do deployment; 
Respeitando a funcionalidade que o Argo tem de validação do state do repo e compara com o contexto atual do manifesto citado! 🚀 