### PR TITLE
Adjusting repository for project cloudnative 🚀

### DIFF
--- a/argo/applications/app-elastichq.yaml
+++ b/argo/applications/app-elastichq.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/guilhermerenew/application-cicd.git
+    repoURL: https://github.com/moonshot-cloudnative/cloudnative-argoproj.git
     targetRevision: HEAD
     path: argo/elastic-hq
     directory:

--- a/argo/applications/app-example.yaml
+++ b/argo/applications/app-example.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/guilhermerenew/application-cicd.git
+    repoURL: https://github.com/moonshot-cloudnative/cloudnative-argoproj.git
     targetRevision: HEAD
     path: argo/example-app
     directory:


### PR DESCRIPTION
Modifiquei o repositorio de referencia dos arquivos para o daqui, porém não é prioritário que os projetos estejam junto com as applications criadas neste repo! O normal é que repositórios com manifestos declarados de outros ms estejam fora desde :) 
A linha modificada faz jus justamente a esse mesmo repo! 💯 
```yaml
  project: default
  source:
    repoURL: https://github.com/moonshot-cloudnative/cloudnative-argoproj.git
    targetRevision: HEAD
    path: argo/elastic-hq
```