### PR TITLE
Adjusting timming

### DIFF
--- a/argo/elastic-hq/ms-elastichq.yaml
+++ b/argo/elastic-hq/ms-elastichq.yaml
@@ -3,23 +3,22 @@ kind: Namespace
 metadata:
   name: elastic-hq
 ---
-#apiVersion: v1
-#kind: Service
-#metadata:
-#  labels:
-#    app: elastichq
-#  name: elastichq
-#  namespace: elastic-hq
-#spec:
-#  ports:
-#  - name: service-port
-#    port: 5000
-#    protocol: TCP
-#    targetPort: 5000
-#  selector:
-#    app: elastichq
-#  type: NodePort
-#---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: elastichq
+  name: elastichq
+  namespace: elastic-hq
+spec:
+  ports:
+  - port: 8000
+    targetPort: 5000
+    protocol: TCP
+  selector:
+    app: elastic-hq
+  type: LoadBalancer
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/argo/elastic-hq/ms-elastichq.yaml
+++ b/argo/elastic-hq/ms-elastichq.yaml
@@ -3,23 +3,23 @@ kind: Namespace
 metadata:
   name: elastic-hq
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: elastichq
-  name: elastichq
-  namespace: elastic-hq
-spec:
-  ports:
-  - name: service-port
-    port: 5000
-    protocol: TCP
-    targetPort: 5000
-  selector:
-    app: elastichq
-  type: NodePort
----
+#apiVersion: v1
+#kind: Service
+#metadata:
+#  labels:
+#    app: elastichq
+#  name: elastichq
+#  namespace: elastic-hq
+#spec:
+#  ports:
+#  - name: service-port
+#    port: 5000
+#    protocol: TCP
+#    targetPort: 5000
+#  selector:
+#    app: elastichq
+#  type: NodePort
+#---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/argo/example-app/ms-example.yaml
+++ b/argo/example-app/ms-example.yaml
@@ -6,20 +6,24 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: example-app
   name: example-service
+  namespace: example-app
 spec:
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
   selector:
     app: example-app
-  ports:
-    - protocol: TCP
-      port: 5000
-      targetPort: 5000
-  type: NodePort
+  type: LoadBalancer
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-deploy
+  namespace: example-app
   labels:
     app: example-app
   annotations:

--- a/argo/installing/install.yaml
+++ b/argo/installing/install.yaml
@@ -3198,18 +3198,21 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
+    application: argocd
   name: argocd-application-controller
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
+      application: argocd
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-application-controller
+        application: argocd
     spec:
       containers:
       - command:
@@ -3244,16 +3247,19 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
+    application: argocd
   name: argocd-dex-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server
+      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-dex-server
+        application: argocd
     spec:
       containers:
       - command:
@@ -3291,16 +3297,19 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
+    application: argocd
   name: argocd-redis
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis
+      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
+        application: argocd
     spec:
       containers:
       - args:
@@ -3321,16 +3330,19 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
+    application: argocd
   name: argocd-repo-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server
+      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
+        application: argocd
     spec:
       automountServiceAccountToken: false
       containers:
@@ -3375,16 +3387,19 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
+    application: argocd
   name: argocd-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-server
+      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
+        application: argocd
     spec:
       containers:
       - command:

--- a/argo/installing/install.yaml
+++ b/argo/installing/install.yaml
@@ -3198,21 +3198,18 @@ metadata:
     app.kubernetes.io/component: application-controller
     app.kubernetes.io/name: argocd-application-controller
     app.kubernetes.io/part-of: argocd
-    application: argocd
   name: argocd-application-controller
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-application-controller
-      application: argocd
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-application-controller
-        application: argocd
     spec:
       containers:
       - command:
@@ -3247,19 +3244,16 @@ metadata:
     app.kubernetes.io/component: dex-server
     app.kubernetes.io/name: argocd-dex-server
     app.kubernetes.io/part-of: argocd
-    application: argocd
   name: argocd-dex-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-dex-server
-      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-dex-server
-        application: argocd
     spec:
       containers:
       - command:
@@ -3297,19 +3291,16 @@ metadata:
     app.kubernetes.io/component: redis
     app.kubernetes.io/name: argocd-redis
     app.kubernetes.io/part-of: argocd
-    application: argocd
   name: argocd-redis
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-redis
-      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-redis
-        application: argocd
     spec:
       containers:
       - args:
@@ -3330,19 +3321,16 @@ metadata:
     app.kubernetes.io/component: repo-server
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: argocd
-    application: argocd
   name: argocd-repo-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server
-      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-repo-server
-        application: argocd
     spec:
       automountServiceAccountToken: false
       containers:
@@ -3387,19 +3375,16 @@ metadata:
     app.kubernetes.io/component: server
     app.kubernetes.io/name: argocd-server
     app.kubernetes.io/part-of: argocd
-    application: argocd
   name: argocd-server
   namespace: argocd
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-server
-      application: argocd
   template:
     metadata:
       labels:
         app.kubernetes.io/name: argocd-server
-        application: argocd
     spec:
       containers:
       - command:

--- a/argo/proxy/ms-proxy.yaml
+++ b/argo/proxy/ms-proxy.yaml
@@ -7,19 +7,21 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-proxy
+  namespace: nginx-app
 spec:
-  selector:
-    app: nginx-proxy
   ports:
-    - protocol: TCP
-      port: 8000
+    - port: 8000
       targetPort: 80
+      protocol: TCP
+  selector:
+    app: ngoinx-app
   type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deploy
+  namespace: nginx-app
   labels:
     app: nginx-app
   annotations:

--- a/argo/proxy/ms-proxy.yaml
+++ b/argo/proxy/ms-proxy.yaml
@@ -15,7 +15,7 @@ spec:
       protocol: TCP
   selector:
     app: ngoinx-app
-  type: NodePort
+  type: LoadBalancer
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## About 
Ajustes para aplicações funcionarem ok em cluster minikube! Doc de referência: https://github.com/kubernetes/minikube/issues/6302
#### LoadBalancer access
A LoadBalancer service is the standard way to expose a service to the internet. With this method, each service gets its own IP address.
#### Using minikube tunnel
Services of type LoadBalancer can be exposed via the minikube tunnel command. It must be run in a separate terminal window to keep the LoadBalancer running. Ctrl-C in the terminal can be used to terminate the process at which time the network routes will be cleaned up.
#### Example
Run tunnel in a separate terminal
it will ask for password.
`minikube tunnel` 
- Minikube tunnel runs as a process, creating a network route on the host to the service CIDR of the cluster using the cluster’s IP address as a gateway. The tunnel command exposes the external IP directly to any program running on the host operating system.

