### PR TITLE
replicas adjusted for non-persistent application

### DIFF
--- a/argo/ms-queuerest/ms-queuerest.yaml
+++ b/argo/ms-queuerest/ms-queuerest.yaml
@@ -32,7 +32,7 @@ spec:
   selector:
     matchLabels:
       app: ms-queuerest
-  replicas: 10
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
### bug! 🐛 
Aplicação `ms-queuerest` deve realizar inserções fixas em metadata padrão para não ocorrer problemas de informações não persistentes ou até mesmo ocorrer perdas de informações com relação aos containers em micro-serviço! 

### WordAround 💡 
Informações estáticas em memória dentro de um único container 😞 